### PR TITLE
Use dataclasses for subjects, materials and lecturers

### DIFF
--- a/bot/handlers/choose_subject.py
+++ b/bot/handlers/choose_subject.py
@@ -7,7 +7,7 @@ async def handle_choose_subject(update, context, text):
         return None
     db = get_db(context)
     subjects = await db.get_subjects_by_level_and_term(level_id, term_id)
-    subject_names = {name for (name,) in subjects}
+    subject_names = {s.name for s in subjects}
     if text in subject_names:
         subject_id = await db.get_subject_id_by_name(level_id, term_id, text)
         if subject_id is None:

--- a/bot/handlers/choose_year_or_lecturer.py
+++ b/bot/handlers/choose_year_or_lecturer.py
@@ -45,7 +45,7 @@ async def handle_choose_year_or_lecturer(update, context, text):
             )
 
     lecturers = await db.get_lecturers_for_subject_section(subject_id, section_code)
-    lect_map = {name: _id for _id, name in lecturers}
+    lect_map = {lec.name: lec.id for lec in lecturers}
     if text in lect_map:
         lecturer_id = lect_map[text]
         nav_set_lecturer(context.user_data, text, lecturer_id)

--- a/bot/handlers/lecture_category_choice.py
+++ b/bot/handlers/lecture_category_choice.py
@@ -26,7 +26,7 @@ async def handle_lecture_category_choice(update, context, text):
     if not mats:
         cats = await db.list_categories_for_lecture(subject_id, section_code, lecture_title, year_id=year_id, lecturer_id=lecturer_id)
         return await update.message.reply_text("لا توجد ملفات لهذا النوع.", reply_markup=generate_lecture_category_menu_keyboard(cats))
-    for _id, title, url in mats:
-        await update.message.reply_text(f"📄 {title}\n{url or '(لا يوجد رابط)'}")
+    for mat in mats:
+        await update.message.reply_text(f"📄 {mat.title}\n{mat.url or '(لا يوجد رابط)'}")
     cats = await db.list_categories_for_lecture(subject_id, section_code, lecture_title, year_id=year_id, lecturer_id=lecturer_id)
     return await update.message.reply_text("اختر نوعًا آخر:", reply_markup=generate_lecture_category_menu_keyboard(cats))

--- a/bot/handlers/lecture_title_choice.py
+++ b/bot/handlers/lecture_title_choice.py
@@ -25,8 +25,8 @@ async def handle_lecture_title_choice(update, context, text):
     if not cats:
         mats = await db.get_lecture_materials(subject_id, section_code, year_id=year_id, lecturer_id=lecturer_id, title=text)
         if mats:
-            for _id, title, url in mats:
-                await update.message.reply_text(f"📄 {title}\n{url or '(لا يوجد رابط)'}")
+            for mat in mats:
+                await update.message.reply_text(f"📄 {mat.title}\n{mat.url or '(لا يوجد رابط)'}")
             titles = await db.list_lecture_titles(subject_id, section_code)
             if year_id and lecturer_id:
                 titles = await db.list_lecture_titles_by_lecturer_year(subject_id, section_code, lecturer_id, year_id)

--- a/bot/handlers/year_category_menu_actions.py
+++ b/bot/handlers/year_category_menu_actions.py
@@ -50,8 +50,8 @@ async def handle_year_category_menu_actions(update, context, text):
                 titles_exist = bool(await db.list_lecture_titles_by_year(subject_id, section_code, year_id))
             cats = await db.list_categories_for_subject_section_year(subject_id, section_code, year_id, lecturer_id=lecturer_id)
             return await update.message.reply_text("لا توجد ملفات لهذا التصنيف.", reply_markup=generate_year_category_menu_keyboard(cats, titles_exist))
-        for _id, title, url in mats:
-            await update.message.reply_text(f"📄 {title}\n{url or '(لا يوجد رابط)'}")
+        for mat in mats:
+            await update.message.reply_text(f"📄 {mat.title}\n{mat.url or '(لا يوجد رابط)'}")
         titles_exist = False
         if lecturer_id and year_id:
             titles_exist = bool(await db.list_lecture_titles_by_lecturer_year(subject_id, section_code, lecturer_id, year_id))

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -4,6 +4,7 @@
 
 from telegram import ReplyKeyboardMarkup
 from .config import ADMIN_USER_IDS
+from .models import Subject, Lecturer
 # -----------------------------------------------------------------------------
 # ثوابت نصوص الأزرار (يجب أن تبقى متطابقة مع ما يستخدمه bot.py)
 # -----------------------------------------------------------------------------
@@ -119,12 +120,12 @@ def generate_terms_keyboard(terms: list) -> ReplyKeyboardMarkup:
         input_field_placeholder="إختر الفصل الدراسي  ⬇️",
     )
 
-def generate_subjects_keyboard(subjects: list) -> ReplyKeyboardMarkup:
+def generate_subjects_keyboard(subjects: list[Subject]) -> ReplyKeyboardMarkup:
     """
     يعرض قائمة مواد الترم الحالي.
-    subjects: [(name,), ...]
+    subjects: [Subject, ...]
     """
-    names = [name for (name,) in subjects]
+    names = [s.name for s in subjects]
     keyboard = _rows(names, cols=2)
     keyboard.append([BACK])
     keyboard.append([BACK_TO_LEVELS])  # الرجوع مباشرة للمستويات من هنا مفيد
@@ -198,12 +199,12 @@ def generate_years_keyboard(years: list[tuple[int, str]]) -> ReplyKeyboardMarkup
     keyboard.append([BACK_TO_LEVELS])
     return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
-def generate_lecturers_keyboard(lecturers: list[tuple[int, str]]) -> ReplyKeyboardMarkup:
+def generate_lecturers_keyboard(lecturers: list[Lecturer]) -> ReplyKeyboardMarkup:
     """
     يعرض المحاضرين المرتبطين بالقسم/المادة.
-    lecturers: [(id, name), ...] — نعرض الاسم كزر.
+    lecturers: [Lecturer, ...] — نعرض الاسم كزر.
     """
-    names = [name for _id, name in lecturers]
+    names = [lec.name for lec in lecturers]
     keyboard = _rows(names, cols=2)
     keyboard.append([BACK, BACK_TO_SUBJECTS])
     keyboard.append([BACK_TO_LEVELS])

--- a/bot/models.py
+++ b/bot/models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Subject:
+    """Represents a study subject."""
+    id: int
+    name: str
+
+
+@dataclass
+class Lecturer:
+    """Represents a lecturer or teaching assistant."""
+    id: int
+    name: str
+    role: str = "lecturer"
+
+
+@dataclass
+class Material:
+    """Represents a material record from the database."""
+    id: int
+    subject_id: int
+    section: str
+    category: str
+    title: str
+    url: Optional[str] = None
+    year_id: Optional[int] = None
+    lecturer_id: Optional[int] = None

--- a/tests/test_db_models.py
+++ b/tests/test_db_models.py
@@ -1,0 +1,47 @@
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from bot.db import Database
+from bot.models import Subject, Lecturer, Material
+from bot.keyboards import generate_subjects_keyboard, generate_lecturers_keyboard
+
+
+def test_db_returns_dataclasses(tmp_path):
+    async def inner():
+        db_file = tmp_path / "test.db"
+        db = Database(str(db_file))
+        async with db:
+            await db.init_db()
+            await db.insert_level("Level1")
+            await db.insert_term("Term1")
+            level_id = await db.get_level_id_by_name("Level1")
+            term_id = await db.get_term_id_by_name("Term1")
+            await db.insert_subject("S1", "Subject1", level_id, term_id)
+            subjects = await db.get_subjects_by_level_and_term(level_id, term_id)
+            assert subjects and isinstance(subjects[0], Subject)
+            subject_id = subjects[0].id
+            lect_id = await db.ensure_lecturer_id("Dr X")
+            await db.insert_material(subject_id, "theory", "lecture", "Intro", "http://url", lecturer_id=lect_id)
+            lecturers = await db.get_lecturers_for_subject_section(subject_id, "theory")
+            assert lecturers and isinstance(lecturers[0], Lecturer)
+            mats = await db.get_lecture_materials(subject_id, "theory")
+            assert mats and isinstance(mats[0], Material)
+
+    asyncio.run(inner())
+
+
+def test_keyboards_accept_dataclasses():
+    subjects = [Subject(id=1, name="Math"), Subject(id=2, name="Physics")]
+    kb = generate_subjects_keyboard(subjects)
+    kb_dict = kb.to_dict()
+    texts = [btn["text"] for row in kb_dict["keyboard"] for btn in row]
+    assert "Math" in texts and "Physics" in texts
+
+    lecturers = [Lecturer(id=1, name="Prof")]
+    kb2 = generate_lecturers_keyboard(lecturers)
+    kb2_dict = kb2.to_dict()
+    texts2 = [btn["text"] for row in kb2_dict["keyboard"] for btn in row]
+    assert "Prof" in texts2


### PR DESCRIPTION
## Summary
- define `Subject`, `Lecturer` and `Material` dataclasses
- return dataclass instances from database queries
- adapt keyboard builders and handlers to work with new objects
- add tests validating dataclass conversions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35ff5eafc832982be19b48b18ec41