### PR TITLE
Refactor bot startup for PTB v21

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -13,6 +13,7 @@ from telegram.ext import (
     MessageHandler,
     filters,
     ContextTypes,
+    idle,
 )
 
 from .config import BOT_TOKEN
@@ -150,7 +151,10 @@ async def main() -> None:
         app.add_handler(conv_handler)
 
         print("✅ Bot is running...")
-        await app.run_polling()
+        async with app:
+            await app.start()
+            await app.updater.start_polling()
+            await idle()
 
 
 


### PR DESCRIPTION
## Summary
- Use explicit async startup instead of deprecated `run_polling`
- Import `idle` and start polling manually with `async with app`

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a49cbd63b88329a95f8976f0bafd63